### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/KAnggara75/scc2go/security/code-scanning/2](https://github.com/KAnggara75/scc2go/security/code-scanning/2)

In general, fix this by adding an explicit `permissions` block with the minimal required scopes. For this workflow, the `semantic-release` job legitimately needs `contents: write` and already declares it. The `build` job only needs read access to the repository contents to check out code and run tests; it does not create tags, releases, or modify issues/PRs. Therefore we should add a `permissions: contents: read` block at the `build` job level.

Concretely, in `.github/workflows/go.yml`, under `jobs: build:` and at the same indentation level as `runs-on: ubuntu-latest`, insert:

```yaml
permissions:
  contents: read
```

This will override any broader repo/org GITHUB_TOKEN defaults for that job, without changing functionality. No additional imports or methods are needed; this is a pure workflow-configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
