### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,6 +20,8 @@ env:
 jobs:
   test:
     name: Test (Go ${{ matrix.go-version }})
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/KAnggara75/scc2go/security/code-scanning/3](https://github.com/KAnggara75/scc2go/security/code-scanning/3)

In general, fix this by explicitly specifying `permissions` either at the workflow root or per job, limiting the `GITHUB_TOKEN` to the minimal scopes required. Jobs that only need to read the repository should typically use `contents: read`; jobs that need to push tags, create releases, or modify issues/PRs can request additional write scopes as necessary.

For this specific code, the `test` job is the one CodeQL flagged and it only checks out code, sets up Go, runs tests, and uploads coverage to Codecov using a secret token. None of these steps require write access to the GitHub repository or other GitHub resources. We should therefore add a `permissions` block to the `test` job, setting `contents: read`. The `build` job already has `permissions: contents: read`, so we will mirror that minimal configuration for `test`. Concretely: in `.github/workflows/CI.yaml`, under `jobs:   test:`, insert a `permissions:` section (e.g., between the `name:` and `runs-on:` lines) specifying `contents: read`. No new imports or external dependencies are needed; this is purely a YAML/workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
